### PR TITLE
Update CI Go versions to 1.25, 1.24, and 1.23

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   lint-and-tests:
     strategy:
       matrix:
-        go-version: ["1.22", "1.23", "1.24"]
+        go-version: ["1.25", "1.24", "1.23"]
         os: [macos-latest, ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates CI to test against newer Go versions.
> 
> - Bumps `go-version` matrix in `.github/workflows/go.yml` to `1.25`, `1.24`, `1.23` (drops `1.22`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2285cde7d4a0c8f6105e179676efe39187e89015. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->